### PR TITLE
chore: remove mp4 from files published to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "display a very bright white color on HDR-enabled displays",
   "main": "index.js",
   "files": [
-    "index.js",
-    "superwhite.mp4"
+    "index.js"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
the video is already included as base64 in `index.js`